### PR TITLE
Add `riscv_fw_version` to `example_config.yml`

### DIFF
--- a/model_configs/example_config/example_config.yml
+++ b/model_configs/example_config/example_config.yml
@@ -1,3 +1,5 @@
 s_t_priv: tropic01_ese_private_key_1.pem
 s_t_pub: tropic01_ese_public_key_1.pem
 x509_certificate: tropic01_ese_certificate_1.pem
+riscv_fw_version: !!binary |
+  AAAAAa==


### PR DESCRIPTION
This PR adds `riscv_fw_version` (=1.0.0) to the `example_config.yml` file, which is used for tests in the TrezorFW repository. 

Rationale: Using the current config file without the `riscv_fw_version` value does not work, as the default value of `riscv_fw_version` does not pass the runtime check (added in libtropic 3.0.0).