### PR TITLE
fix(model): serialize partition slot keys as plain int

### DIFF
--- a/tvl/targets/model/internal/generic_partition.py
+++ b/tvl/targets/model/internal/generic_partition.py
@@ -47,7 +47,7 @@ class GenericPartition(DefaultDict[int, T]):
         Returns:
             the content of the partition
         """
-        return {k: v.to_dict() for k, v in self.items()}
+        return {int(k): v.to_dict() for k, v in self.items()}
 
     @classmethod
     def from_dict(cls, __mapping: Mapping[int, Any], /) -> Self:


### PR DESCRIPTION
Even though the `GenericPartition` is defined as `DefaultDict[int, T]`, its items get serialized as `IntEnum`, which breaks `yaml.safe_load` function - the items are serialized as `!!python/object/apply:...SlotEnum [N]`.

This change serializes the items as plain `int`.