### PR TITLE
fix: allow blank and invalidated pairing key slots in configuration

### DIFF
--- a/tests/test_model_internal/test_pairing_keys.py
+++ b/tests/test_model_internal/test_pairing_keys.py
@@ -4,6 +4,7 @@ from contextlib import nullcontext
 from typing import Any, ContextManager
 
 import pytest
+from pydantic import ValidationError
 
 from tvl.targets.model.internal.pairing_keys import (
     KEY_SIZE,
@@ -11,6 +12,7 @@ from tvl.targets.model.internal.pairing_keys import (
     InvalidatedSlotError,
     PairingKeys,
     PairingKeySlot,
+    PairingKeySlotModel,
     SlotState,
     WrittenSlotError,
 )
@@ -166,3 +168,71 @@ def test_dict():
     pairing_keys = PairingKeys.from_dict(pairing_key_dict)
     assert pairing_keys.to_dict() == pairing_key_dict
     assert pairing_keys[slot].to_dict() == pairing_key_slot_dict
+
+
+@pytest.mark.parametrize(
+    "state, value, context",
+    [
+        pytest.param(
+            SlotState.WRITTEN,
+            os.urandom(KEY_SIZE),
+            nullcontext(),
+            id="written_correct_size",
+        ),
+        pytest.param(
+            SlotState.WRITTEN,
+            b"",
+            pytest.raises(ValidationError),
+            id="written_empty",
+        ),
+        pytest.param(
+            SlotState.WRITTEN,
+            os.urandom(KEY_SIZE - 1),
+            pytest.raises(ValidationError),
+            id="written_wrong_size",
+        ),
+        pytest.param(
+            SlotState.INVALID,
+            b"",
+            nullcontext(),
+            id="invalidated_empty",
+        ),
+        pytest.param(
+            SlotState.INVALID,
+            os.urandom(KEY_SIZE),
+            pytest.raises(ValidationError),
+            id="invalidated_not_empty",
+        ),
+        pytest.param(
+            SlotState.BLANK,
+            b"",
+            nullcontext(),
+            id="blank_empty",
+        ),
+        pytest.param(
+            SlotState.BLANK,
+            os.urandom(KEY_SIZE),
+            pytest.raises(ValidationError),
+            id="blank_not_empty",
+        ),
+    ],
+)
+def test_pairing_key_slot_model_validation(
+    state: SlotState, value: bytes, context: ContextManager[Any]
+):
+    with context:
+        model = PairingKeySlotModel(value=value, state=state)
+        assert model.value == value
+        assert model.state is state
+
+
+def test_invalidated_slot_configuration_round_trip():
+    """A slot invalidated at runtime must be reloadable from its dumped state."""
+    slot = PairingKeySlot(value=os.urandom(KEY_SIZE), state=SlotState.WRITTEN)
+    slot.invalidate()
+
+    dumped = slot.to_dict()
+    model = PairingKeySlotModel(**dumped)
+
+    assert model.state is SlotState.INVALID
+    assert model.value == b""

--- a/tvl/targets/model/internal/pairing_keys.py
+++ b/tvl/targets/model/internal/pairing_keys.py
@@ -2,10 +2,9 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Mapping
 
-from pydantic import BaseModel
+from pydantic import BaseModel, StrictBytes, validator
 from typing_extensions import Self
 
-from ....typing_utils import FixedSizeBytes
 from .generic_partition import BaseSlot, GenericModel, GenericPartition
 
 KEY_SIZE = 32
@@ -117,8 +116,24 @@ class PairingKeys(GenericPartition[PairingKeySlot]):
 
 
 class PairingKeySlotModel(BaseModel):
-    value: FixedSizeBytes[KEY_SIZE]
+    value: StrictBytes = b""
     state: SlotState = SlotState.WRITTEN
+
+    @validator("state")
+    def _check_value_matches_state(  # noqa: N805
+        cls, state: SlotState, values: Dict[str, Any]
+    ) -> SlotState:
+        # `value` is absent from `values` if it already failed validation.
+        if (value := values.get("value")) is None:
+            return state
+        if state is SlotState.WRITTEN:
+            if (ln := len(value)) != KEY_SIZE:
+                raise ValueError(
+                    f"a written pairing key must be {KEY_SIZE} bytes long: got {ln}"
+                )
+        elif value:
+            raise ValueError(f"a {state} pairing key slot must have an empty value")
+        return state
 
 
 class PairingKeysModel(GenericModel):


### PR DESCRIPTION
Fixes #16.

## The problem

`PairingKeySlot.invalidate()` clears the slot value, and a blank slot
starts empty, but `PairingKeySlotModel` required exactly `KEY_SIZE`
bytes regardless of state. A configuration dumped after invalidating a
slot therefore could not be loaded back.

The round trip breaks on the one operation that is irreversible on real
silicon — which is the case where being able to reload the state matters
most.

## Reproduction

Note: the config in #16 no longer starts on 2.5, because
`x509_certificate` is required by `ConfigurationModel` in
`tvl/server/configuration.py` while `ModelConfigurationModel` in
`tvl/configuration_file_model.py` declares it `Optional`. Reproduced
using `model_configs/example_config` plus the pairing key from the
issue.

1. Start the model with a written pairing key in slot 0 and `-o out.yml`
2. Invalidate slot 0 via `TsL3PairingKeyInvalidateCommand`
3. Stop the server — `out.yml` now contains `state: invalid`,
   `value: !!binary ""`
4. `model_server tcp -c out.yml` fails with
   `ensure this value has at least 32 characters`

## The fix

Validation is now conditional on slot state, in both directions:

- `WRITTEN` requires exactly `KEY_SIZE` bytes
- `BLANK` and `INVALID` require an empty value

The second direction was not checked at all before, so a full-size value
in an invalidated slot was silently accepted.

`user_data_partition` already permits empty slot values via
`SizedBytes[0, ...]`; this brings pairing keys in line with that.

## Tests

Parametrised tests for all seven state/value combinations, plus a
round-trip test that invalidates a slot and reloads it from its dumped
state.

`tests/test_model_internal`: 81 passed.
Full suite: 7766 passed, 35 skipped.
Coverage of `pairing_keys.py`: 79% → 95%.