### PR TITLE
fix: import ValidationError and StrictInt from pydantic.v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Tests: `test_server/test_configuration.py` expected `pydantic.ValidationError`, but
+  since the pydantic v2 migration (#15) the configuration models raise
+  `pydantic.v1.ValidationError`; two tests failed deterministically
+- Configuration object generator template imported `StrictInt` from `pydantic`
+  instead of `pydantic.v1`, so regenerating `configuration_object_impl.py` would
+  mix v1 models with a v2 type
+
 ## [2.5]
 
 ### Changed

--- a/tests/test_server/test_configuration.py
+++ b/tests/test_server/test_configuration.py
@@ -8,7 +8,6 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
     derive_private_key,
     generate_private_key,
 )
-from pydantic import ValidationError
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from cryptography.hazmat.primitives.serialization import (
@@ -17,6 +16,7 @@ from cryptography.hazmat.primitives.serialization import (
     PrivateFormat,
     PublicFormat,
 )
+from pydantic.v1 import ValidationError
 
 from tests.test_crypto.test_ecdsa import PRIV_KEY as _RFC6979_PRIV_KEY
 from tests.test_crypto.test_ecdsa import UX as _RFC6979_UX

--- a/tvl/configuration_object_generator/templates/configuration_object_impl.py.j2
+++ b/tvl/configuration_object_generator/templates/configuration_object_impl.py.j2
@@ -15,7 +15,7 @@
 
 from typing import Optional
 
-from pydantic import StrictInt
+from pydantic.v1 import StrictInt
 
 from tvl.targets.model.internal.configuration_object import (
     ConfigObjectField,


### PR DESCRIPTION
The pydantic v2 migration (#15) moved all models to the pydantic.v1 compatibility layer, so ValidationError raised by the server configuration models is pydantic.v1.ValidationError. Two tests in tests/test_server/test_configuration.py still imported the v2 class and failed deterministically.

The configuration object generator template still imported StrictInt from pydantic, diverging from the committed generated file; regenerating would mix a v2 type into v1 models.